### PR TITLE
Fix profile update with empty numeric fields

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2447,9 +2447,23 @@ def update_user_profile():
         return jsonify({'error': 'Não autenticado'}), 401
 
     data = request.get_json() or {}
+    numeric_int = ['age']
+    numeric_float = ['height', 'current_weight', 'target_weight']
     for field in ['username', 'email', 'age', 'height', 'current_weight', 'target_weight', 'gender']:
         if field in data:
-            setattr(user, field, data[field])
+            value = data[field]
+            if value == '' or value is None:
+                setattr(user, field, None)
+            else:
+                try:
+                    if field in numeric_int:
+                        setattr(user, field, int(value))
+                    elif field in numeric_float:
+                        setattr(user, field, float(value))
+                    else:
+                        setattr(user, field, value)
+                except (ValueError, TypeError):
+                    setattr(user, field, None)
     db.session.commit()
     return jsonify({'message': 'Perfil atualizado'}), 200
 


### PR DESCRIPTION
## Summary
- handle empty numeric values when updating the user profile

## Testing
- `python3 -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68404dec7a048330ba1a20d46f967b0a