### PR TITLE
Add offline mode for Azure AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Nutrivision is a demo application that combines a Flask backend with a React fro
    export AZURE_OPENAI_DEPLOYMENT=your-deployment
    export AZURE_OPENAI_API_VERSION=2024-12-01-preview
    ```
+   If the OpenAI Python package or network access is not available, the
+   backend will automatically fall back to mock responses so the demo can
+   still run offline.
 5. Start the Flask server:
    ```bash
    flask --app app.py run


### PR DESCRIPTION
## Summary
- fall back to mock responses when Azure OpenAI client isn't available
- document offline fallback in the README

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68407b1f10f8833096eadcac48659f37