### PR TITLE
Improve meal logging with photo-based titles

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1917,8 +1917,12 @@ def analyze_meal_revolutionary():
         new_badges = check_revolutionary_badges(user)
         update_food_memories(user.id, ai_data.get('foods_detected', []), meal_analysis)
 
+        foods = ai_data.get('foods_detected', [])
+        suggested_title = generate_meal_title(", ".join(foods)) if foods else None
+
         return jsonify({
             'analysis': {
+                'title': suggested_title,
                 'foods_detected': ai_data.get('foods_detected', []),
                 'nutrition': nutrition,
                 'revolutionary_insights': {
@@ -2823,10 +2827,16 @@ def add_daily_meal():
             carbs = estimates['carbs']
             fat = estimates['fat']
         else:
-            calories = int(data['calories'])
-            protein = float(data['protein'])
-            carbs = float(data['carbs'])
-            fat = float(data['fat'])
+            try:
+                calories = int(data['calories'])
+                protein = float(data['protein'])
+                carbs = float(data['carbs'])
+                fat = float(data['fat'])
+            except (ValueError, TypeError):
+                return jsonify({'error': 'Valores nutricionais inválidos'}), 400
+
+            if calories == 0 and protein == 0 and carbs == 0 and fat == 0:
+                return jsonify({'error': 'Forneça valores nutricionais ou use a estimativa AI'}), 400
 
         new_meal = DailyMeal(
             user_id=user.id,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -511,6 +511,15 @@ const NutriVisionApp = () => {
       setError('Please enter a meal name');
       return;
     }
+    if (
+      !currentMeal.calories &&
+      !currentMeal.protein &&
+      !currentMeal.carbs &&
+      !currentMeal.fat
+    ) {
+      setError('Run AI estimation or fill in nutrition before saving');
+      return;
+    }
     const newMeal = {
       id: Date.now(),
       ...currentMeal,
@@ -587,10 +596,13 @@ const NutriVisionApp = () => {
 
       if (result.estimation) {
         if (result.estimation.title) {
-          setCurrentMeal((prev) => ({ ...prev, name: result.estimation.title }));
+          setAiMealEstimation(result.estimation);
+          if (!currentMeal.name.trim()) {
+            setCurrentMeal((prev) => ({ ...prev, name: result.estimation.title }));
+          }
+        } else {
+          setAiMealEstimation(result.estimation);
         }
-
-        setAiMealEstimation(result.estimation);
         setCurrentMeal((prev) => ({
           ...prev,
           calories: result.estimation.calories.toString(),
@@ -601,13 +613,16 @@ const NutriVisionApp = () => {
       } else if (result.analysis) {
         const nutrition = result.analysis.nutrition || {};
         setAiMealEstimation({
-          title: currentMeal.name,
+          title: result.analysis.title || currentMeal.name,
           calories: nutrition.calories || 0,
           protein: nutrition.protein || 0,
           carbs: nutrition.carbs || 0,
           fat: nutrition.fat || 0,
           confidence: null,
         });
+        if (!currentMeal.name.trim() && result.analysis.title) {
+          setCurrentMeal((prev) => ({ ...prev, name: result.analysis.title }));
+        }
         setCurrentMeal((prev) => ({
           ...prev,
           calories: String(nutrition.calories || ''),


### PR DESCRIPTION
## Summary
- generate meal title from foods detected when analyzing meal images
- enforce nutrition fields when saving meals
- keep user-provided meal name unless empty
- use suggested title from image analysis if provided

## Testing
- `python3 -m py_compile backend/app.py`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a6ce83cc8330ba6a7f3fd334b068