### PR TITLE
Remove static meal suggestions

### DIFF
--- a/App.js
+++ b/App.js
@@ -60,7 +60,6 @@ const NutriVisionApp = () => {
   });
 
   // Dashboard & Stats
-  const [mealSuggestions, setMealSuggestions] = useState([]);
   const [dashboardStats, setDashboardStats] = useState(null);
 
   // Daily Log & “Add Meal”
@@ -202,7 +201,6 @@ const NutriVisionApp = () => {
       setTimeout(async () => {
         try {
           await loadDashboardStats();
-          await loadMealSuggestions();
         } catch (_) { }
       }, 300);
       showSuccess(`Welcome back, ${res.user.username}!`);
@@ -234,7 +232,6 @@ const NutriVisionApp = () => {
       setTimeout(async () => {
         try {
           await loadDashboardStats();
-          await loadMealSuggestions();
         } catch (_) { }
       }, 300);
       showSuccess(`🎉 Welcome, ${res.user.username}!`);
@@ -306,7 +303,6 @@ const NutriVisionApp = () => {
             break;
           case 'dashboard':
             loadDashboardStats();
-            loadMealSuggestions();
             break;
           case 'menstrual-cycle':
             if (user.gender === 'female' && user.track_menstrual_cycle) {
@@ -353,17 +349,6 @@ const NutriVisionApp = () => {
       console.error('Error loading dashboard stats:', err);
     }
   };
-
-  const loadMealSuggestions = async () => {
-    try {
-      const res = await apiCall('/meal-suggestions');
-      setMealSuggestions(res.suggestions || []);
-    } catch (err) {
-      console.error('Error loading meal suggestions:', err);
-      setMealSuggestions([]);
-    }
-  };
-
   const loadDailyMeals = async () => {
     setLoading(true);
     try {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -64,7 +64,6 @@ const NutriVisionApp = () => {
   });
 
   // Dashboard & Stats
-  const [mealSuggestions, setMealSuggestions] = useState([]);
   const [dashboardStats, setDashboardStats] = useState(null);
 
   // Daily Log & “Add Meal”
@@ -206,7 +205,6 @@ const NutriVisionApp = () => {
       setTimeout(async () => {
         try {
           await loadDashboardStats();
-          await loadMealSuggestions();
         } catch (_) { }
       }, 300);
       showSuccess(`Welcome back, ${res.user.username}!`);
@@ -238,7 +236,6 @@ const NutriVisionApp = () => {
       setTimeout(async () => {
         try {
           await loadDashboardStats();
-          await loadMealSuggestions();
         } catch (_) { }
       }, 300);
       showSuccess(`Welcome, ${res.user.username}!`);
@@ -307,7 +304,6 @@ const NutriVisionApp = () => {
             break;
           case 'dashboard':
             loadDashboardStats();
-            loadMealSuggestions();
             break;
           case 'profile':
             loadUserProfile();
@@ -363,16 +359,6 @@ const NutriVisionApp = () => {
       setDashboardStats(res);
     } catch (err) {
       console.error('Error loading dashboard stats:', err);
-    }
-  };
-
-  const loadMealSuggestions = async () => {
-    try {
-      const res = await apiCall('/meal-suggestions');
-      setMealSuggestions(res.suggestions || []);
-    } catch (err) {
-      console.error('Error loading meal suggestions:', err);
-      setMealSuggestions([]);
     }
   };
 
@@ -1283,21 +1269,6 @@ const NutriVisionApp = () => {
             </div>
           </div>
 
-          {mealSuggestions.length > 0 && (
-            <div className="bg-white rounded-3xl shadow-lg p-6 border border-gray-100">
-              <h3 className="font-bold text-gray-900 mb-4">Meal Suggestions</h3>
-              <ul className="space-y-2">
-                {mealSuggestions.map((sug, idx) => (
-                  <li key={idx} className="flex items-start space-x-2">
-                    <CheckCircle className="w-4 h-4 mt-1 text-orange-500" />
-                    <span className="text-sm text-gray-700">
-                      {sug.title} - {sug.description}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- strip meal suggestion state and loader
- stop calling meal suggestions on login/register/dashboard
- drop the meal suggestion section from the dashboard

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841466b830483308a6e766caf94100e