### PR TITLE
Fix meal deletion

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2933,6 +2933,28 @@ def add_daily_meal():
         return jsonify({'error': f'Falha ao adicionar refeição: {str(e)}'}), 500
 
 # ------------------------
+# NOVA ROTA: REMOVER REFEIÇÃO DO LOG DIÁRIO (DELETE)
+# ------------------------
+@app.route('/api/daily-meals/<int:meal_id>', methods=['DELETE'])
+def delete_daily_meal(meal_id):
+    user = get_current_user()
+    if not user:
+        return jsonify({'error': 'Não autenticado'}), 401
+
+    try:
+        meal = DailyMeal.query.get_or_404(meal_id)
+        if meal.user_id != user.id:
+            return jsonify({'error': 'Não autorizado'}), 403
+
+        db.session.delete(meal)
+        db.session.commit()
+
+        return jsonify({'message': 'Refeição removida do log diário'}), 200
+    except Exception as e:
+        logger.error(f"❌ Erro ao remover refeição diária: {str(e)}")
+        return jsonify({'error': f'Falha ao remover refeição: {str(e)}'}), 500
+
+# ------------------------
 # GERAÇÃO DE IMAGEM DE RECEITA
 # ------------------------
 

--- a/frontend/src/App copy 2.js
+++ b/frontend/src/App copy 2.js
@@ -2526,9 +2526,17 @@ const NutriVisionApp = () => {
     setShowMealForm(false);
   };
 
-  const deleteMeal = (mealId) => {
-    setDailyMeals((prev) => prev.filter((meal) => meal.id !== mealId));
-    showSuccess('Meal removed! 🗑️');
+  const deleteMeal = async (mealId) => {
+    try {
+      await apiCall(`/daily-meals/${mealId}`, { method: 'DELETE' });
+      setDailyMeals((prev) => prev.filter((meal) => meal.id !== mealId));
+      await loadDashboardStats();
+      showSuccess('Meal removed! 🗑️');
+    } catch (err) {
+      console.error('Error removing meal:', err);
+      setDailyMeals((prev) => prev.filter((meal) => meal.id !== mealId));
+      showSuccess('Meal removed locally! 🗑️');
+    }
   };
 
   const logCycleData = async (data) => {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1009,9 +1009,17 @@ const NutriVisionApp = () => {
     setShowMealForm(false);
   };
 
-  const deleteMeal = (mealId) => {
-    setDailyMeals((prev) => prev.filter((m) => m.id !== mealId));
-    showSuccess('Meal removed!');
+  const deleteMeal = async (mealId) => {
+    try {
+      await apiCall(`/daily-meals/${mealId}`, { method: 'DELETE' });
+      setDailyMeals((prev) => prev.filter((m) => m.id !== mealId));
+      await loadDashboardStats();
+      showSuccess('Meal removed!');
+    } catch (err) {
+      console.error('Error removing meal:', err);
+      setDailyMeals((prev) => prev.filter((m) => m.id !== mealId));
+      showSuccess('Meal removed locally!');
+    }
   };
 
   // ─────────── AI‐ASSISTED MEAL ESTIMATION ───────────


### PR DESCRIPTION
## Summary
- allow deletion of logged meals in backend
- delete meals via API in frontend

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841747a2c0c833099ec48fa0d6a8b95