### PR TITLE
Remove eye logo from NutriSnap pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1389,12 +1389,6 @@ const NutriVisionApp = () => {
       <div className="bg-white rounded-3xl shadow-2xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="flex items-center space-x-3 justify-center">
-            <div className="relative">
-              <div className="w-12 h-12 bg-gradient-to-br from-light-accent via-light-accent2 to-light-accent dark:from-dark-accent dark:via-dark-accent2 dark:to-dark-accent rounded-2xl flex items-center justify-center shadow-lg">
-                <Eye className="w-7 h-7 text-white" />
-              </div>
-              <div className="absolute -top-1 -right-1 w-4 h-4 bg-yellow-400 rounded-full border-2 border-white animate-pulse" />
-            </div>
             <div>
               <h1 className="text-2xl font-black text-gray-900">
                 Nutri<span className="text-orange-500">Snap</span>
@@ -1502,12 +1496,6 @@ const NutriVisionApp = () => {
       <div className="bg-white rounded-3xl shadow-2xl p-8 w-full max-w-md max-h-screen overflow-y-auto">
         <div className="text-center mb-6">
           <div className="flex items-center space-x-3 justify-center">
-            <div className="relative">
-              <div className="w-12 h-12 bg-gradient-to-br from-light-accent via-light-accent2 to-light-accent dark:from-dark-accent dark:via-dark-accent2 dark:to-dark-accent rounded-2xl flex items-center justify-center shadow-lg">
-                <Eye className="w-7 h-7 text-white" />
-              </div>
-              <div className="absolute -top-1 -right-1 w-4 h-4 bg-yellow-400 rounded-full border-2 border-white animate-pulse" />
-            </div>
             <div>
               <h1 className="text-2xl font-black text-gray-900">
                 Nutri<span className="text-orange-500">Snap</span>
@@ -1688,12 +1676,6 @@ const NutriVisionApp = () => {
       <div className="bg-white rounded-3xl shadow-lg p-6 mb-6 border border-gray-100">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center space-x-3">
-            <div className="relative">
-              <div className="w-12 h-12 bg-gradient-to-br from-light-accent via-light-accent2 to-light-accent dark:from-dark-accent dark:via-dark-accent2 dark:to-dark-accent rounded-2xl flex items-center justify-center shadow-lg">
-                <Eye className="w-7 h-7 text-white" />
-              </div>
-              <div className="absolute -top-1 -right-1 w-4 h-4 bg-yellow-400 rounded-full border-2 border-white animate-pulse" />
-            </div>
             <div>
               <h1 className="text-2xl font-black text-gray-900">
                 Nutri<span className="text-orange-500">Snap</span>


### PR DESCRIPTION
## Summary
- strip out the Eye icon from the Nutri Snap header on login, registration, and dashboard views

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417c357b8883308594c123593af633