### PR TITLE
Fix Tailwind postcss plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Nutrivision is a demo application that combines a Flask backend with a React fro
 2. Install dependencies:
    ```bash
    npm install
-   # Tailwind CSS 4.x requires the PostCSS plugin
-   npm install --save-dev @tailwindcss/postcss
    ```
+   The required `@tailwindcss/postcss` plugin is already listed in
+   `package.json` and will be installed automatically.
 3. Start the React development server:
    ```bash
    npm start

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,9 @@
+// Tailwind CSS 4 moved its PostCSS plugin to the
+// `@tailwindcss/postcss` package. Configure PostCSS
+// to use that plugin along with Autoprefixer.
 module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('@tailwindcss/postcss'),
+    require('autoprefixer'),
+  ],
 };


### PR DESCRIPTION
## Summary
- configure PostCSS with `@tailwindcss/postcss`
- clarify that the PostCSS plugin installs automatically

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841803eab7083309e251bc8fdc5798e