### PR TITLE
Fix npm dependencies for CRA build

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,9 @@
       "name": "nutrivision-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@tailwindcss/vite": "^4.1.8",
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-qr-reader": "^3.0.0-beta-1",
         "react-scripts": "5.0.1",
         "web-vitals": "^3.3.2"
       },
@@ -3621,20 +3619,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/vite": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.8.tgz",
-      "integrity": "sha512-CQ+I8yxNV5/6uGaJjiuymgw0kEQiNKRinYbZXPdx1fk5WgiyReG0VaUx/Xq6aVNSUNJFzxm6o8FNKS5aMaim5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@tailwindcss/node": "4.1.8",
-        "@tailwindcss/oxide": "4.1.8",
-        "tailwindcss": "4.1.8"
-      },
-      "peerDependencies": {
-        "vite": "^5.2.0 || ^6"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -14280,36 +14264,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
-    },
-    "node_modules/react-qr-reader": {
-      "version": "3.0.0-beta-1",
-      "resolved": "https://registry.npmjs.org/react-qr-reader/-/react-qr-reader-3.0.0-beta-1.tgz",
-      "integrity": "sha512-5HeFH9x/BlziRYQYGK2AeWS9WiKYZtGGMs9DXy3bcySTX3C9UJL9EwcPnWw8vlf7JP4FcrAlr1SnZ5nsWLQGyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@zxing/browser": "0.0.7",
-        "@zxing/library": "^0.18.3",
-        "rollup": "^2.67.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/react-qr-reader/node_modules/rollup": {
-      "version": "2.79.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,9 @@
   "private": true,
   "proxy": "http://localhost:5001",
   "dependencies": {
-    "@tailwindcss/vite": "^4.1.8",
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-qr-reader": "^3.0.0-beta-1",
     "react-scripts": "5.0.1",
     "web-vitals": "^3.3.2"
   },


### PR DESCRIPTION
## Summary
- remove unused `react-qr-reader` and vite plugin from the frontend deps

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden fetching @tailwindcss/postcss)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684184e7a3c08330b2748f00ec118674