### PR TITLE
Add new dietary and quick options

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1375,7 +1375,15 @@ def customize_for_preferences(config, preferences, index):
         customizations['creative_constraints'] = 'Balance of temperatures and textures allowed.'
 
     # Tempo de preparo
-    if preferences['cooking_time'] == 'quick':
+    if preferences['cooking_time'] == 'ultra-quick':
+        customizations['time_range'] = {
+            'prep_min': 0,
+            'prep_max': 5,
+            'cook_min': 0,
+            'cook_max': 5
+        }
+        customizations['difficulty'] = 'beginner'
+    elif preferences['cooking_time'] == 'quick':
         customizations['time_range'] = {
             'prep_min': max(5, customizations.get('time_range', {}).get('prep_min', 10) - 5),
             'prep_max': max(10, customizations.get('time_range', {}).get('prep_max', 15) - 5),
@@ -1394,7 +1402,11 @@ def customize_for_preferences(config, preferences, index):
 
     # Estilo culinário
     if preferences['cuisine_style'] != 'any':
-        customizations['cuisine_expertise'] = f"{preferences['cuisine_style']} cuisine mastery"
+        if preferences['cuisine_style'] == 'traditional':
+            customizations['cuisine_expertise'] = 'traditional Portuguese cuisine'
+            customizations['inspiration'] += ', classics like bacalhau \u00e0 br\u00e1s and caldo verde'
+        else:
+            customizations['cuisine_expertise'] = f"{preferences['cuisine_style']} cuisine mastery"
         customizations['style_tag'] = preferences['cuisine_style']
 
     return customizations

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2144,6 +2144,7 @@ const NutriVisionApp = () => {
                   }
                   className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 bg-white"
                 >
+                  <option value="ultra-quick">Ultra Quick (&lt;5 min)</option>
                   <option value="quick">Quick (&lt;20 min)</option>
                   <option value="medium">Medium (20–45 min)</option>
                   <option value="elaborate">Elaborate (&gt;45 min)</option>
@@ -2195,6 +2196,8 @@ const NutriVisionApp = () => {
                 <option value="vegan">Vegan</option>
                 <option value="keto">Keto</option>
                 <option value="low-carb">Low Carb</option>
+                <option value="gluten-free">Gluten Free</option>
+                <option value="lactose-free">Lactose Free</option>
                 <option value="high-protein">High Protein</option>
               </select>
             </div>


### PR DESCRIPTION
## Summary
- support "Ultra Quick" meals and extra dietary options in the React UI
- allow `ultra-quick` cooking time on the backend
- make "Traditional" recipes lean to Portuguese cuisine

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68419bc94f808330a2919e25fc7f04e1