### PR TITLE
Add delete option for meal history

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2766,6 +2766,35 @@ def get_meal_history():
         return jsonify({'error': f'Failed to get meal history: {str(e)}'}), 500
 
 # ------------------------
+# REMOVER HISTÓRICO DE REFEIÇÃO (DELETE)
+# ------------------------
+@app.route('/api/meal-history/<int:analysis_id>', methods=['DELETE'])
+def delete_meal_history(analysis_id):
+    """Remove um registro de análise de refeição."""
+    user = get_current_user()
+    if not user:
+        return jsonify({'error': 'Não autenticado'}), 401
+
+    try:
+        analysis = MealAnalysis.query.get_or_404(analysis_id)
+        if analysis.user_id != user.id:
+            return jsonify({'error': 'Não autorizado'}), 403
+
+        if analysis.image_path and os.path.exists(analysis.image_path):
+            try:
+                os.remove(analysis.image_path)
+            except OSError:
+                pass
+
+        db.session.delete(analysis)
+        db.session.commit()
+
+        return jsonify({'message': 'Análise removida'}), 200
+    except Exception as e:
+        logger.error(f"❌ Erro ao excluir análise: {str(e)}")
+        return jsonify({'error': f'Falha ao excluir análise: {str(e)}'}), 500
+
+# ------------------------
 # DASHBOARD STATS (GET)
 # ------------------------
 @app.route('/api/dashboard-stats', methods=['GET'])

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -929,6 +929,17 @@ const NutriVisionApp = () => {
     }
   };
 
+  const deleteHistoryMeal = async (analysisId) => {
+    try {
+      await apiCall(`/meal-history/${analysisId}`, { method: 'DELETE' });
+      setMealHistory((prev) => prev.filter((m) => m.id !== analysisId));
+      showSuccess('Meal analysis deleted!');
+    } catch (err) {
+      console.error('Error deleting meal analysis:', err);
+      setError('Failed to delete meal analysis');
+    }
+  };
+
   const loadUserProfile = async () => {
     try {
       const res = await apiCall('/user-profile');
@@ -2680,8 +2691,10 @@ const NutriVisionApp = () => {
         {mealHistory.length > 0 ? (
           <div className="space-y-4">
             {mealHistory.map((meal) => (
-              <button
+              <div
                 key={meal.id}
+                role="button"
+                tabIndex={0}
                 onClick={() => {
                   setSelectedHistoryMeal(meal);
                   setCurrentView('meal-details');
@@ -2703,7 +2716,7 @@ const NutriVisionApp = () => {
                       {meal.meal_type} • {meal.eating_personality_type || 'Balanced Eater'}
                     </p>
                   </div>
-                  <div className="text-right ml-4">
+                  <div className="text-right ml-4 flex flex-col items-end">
                     <div
                       className={`text-lg font-bold ${meal.health_score >= 8
                         ? 'text-green-600'
@@ -2715,6 +2728,15 @@ const NutriVisionApp = () => {
                       {meal.health_score}/10
                     </div>
                     <div className="text-xs text-gray-600">Health Score</div>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        deleteHistoryMeal(meal.id);
+                      }}
+                      className="text-red-600 hover:text-red-700 p-1 mt-1"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
                   </div>
                 </div>
 
@@ -2747,7 +2769,7 @@ const NutriVisionApp = () => {
                     <div className="text-xs text-gray-600">Fat</div>
                   </div>
                 </div>
-              </button>
+              </div>
             ))}
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- allow deleting meal analysis entries through a new backend route
- call the new route from the frontend and add delete buttons in Meal History view

## Testing
- `python -m py_compile backend/app.py`
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a016bf1083309617d136cd3367d3