### PR TITLE
Fix meal analyses count after deleting history

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -929,11 +929,22 @@ const NutriVisionApp = () => {
     }
   };
 
+  const refreshAdvancedStats = async () => {
+    try {
+      const stats = await apiCall('/user/stats-advanced');
+      setUser(stats.user);
+      setUserStats(stats);
+    } catch (err) {
+      console.error('Error refreshing stats:', err);
+    }
+  };
+
   const deleteHistoryMeal = async (analysisId) => {
     try {
       await apiCall(`/meal-history/${analysisId}`, { method: 'DELETE' });
       setMealHistory((prev) => prev.filter((m) => m.id !== analysisId));
       showSuccess('Meal analysis deleted!');
+      refreshAdvancedStats();
     } catch (err) {
       console.error('Error deleting meal analysis:', err);
       setError('Failed to delete meal analysis');


### PR DESCRIPTION
## Summary
- refresh advanced stats after deleting a meal analysis so the dashboard count matches history

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a20395148330b22a073cacfc138b