### PR TITLE
Remove satisfaction metric from insights

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1930,15 +1930,6 @@ const NutriVisionApp = () => {
                       <Sparkles className="w-6 h-6 mr-2" />
                       Smart Insights
                     </h3>
-                    <div className="grid grid-cols-2 gap-4 mb-4">
-                      <div className="bg-white bg-opacity-20 p-3 rounded-xl">
-                        <div className="text-sm text-orange-100">Satisfaction</div>
-                        <div className="text-2xl font-bold">
-                          {analysisResult.revolutionary_insights?.satisfaction_prediction || 7.5}
-                          /10
-                        </div>
-                      </div>
-                    </div>
                     <div className="bg-white bg-opacity-20 p-4 rounded-xl">
                       <div className="flex items-center space-x-2 mb-2">
                         <Brain className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- remove the `Satisfaction` metric from the Smart Insights section

## Testing
- `npm test -- -w 0` *(fails: `react-scripts` not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841a2ae24e8833085f15c5de42a3389