### PR TITLE
Fix renderRecipeBook closing bracket

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2052,7 +2052,8 @@ const NutriVisionApp = () => {
 
 
   // ─────────── RECIPE BOOK ───────────
-  const renderRecipeBook = () => (
+  const renderRecipeBook = () => {
+    return (
     <div className="min-h-screen bg-gradient-to-br from-yellow-50 to-orange-50 p-6 pb-24">
       <div className="flex items-center justify-between mb-6">
         <button
@@ -2513,6 +2514,7 @@ const NutriVisionApp = () => {
 
     </div>
   );
+  };
 
 
   const renderRecipeDetails = () => {


### PR DESCRIPTION
## Summary
- close `renderRecipeBook` using curly-brace style to avoid syntax error

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a8ba1c9083308fa02d4d6b4873be